### PR TITLE
feat: add gitleaks to prek pre-commit hooks and makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: verify fix lint format type-check install test docs docs-serve
+.PHONY: verify fix lint format type-check install test docs docs-serve secrets pysentry
 
 # Verify - check everything without making changes
 verify: lint format-check type-check

--- a/template/{% if include_prek %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template/{% if include_prek %}.pre-commit-config.yaml{% endif %}.jinja
@@ -22,18 +22,23 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  # ty - Astral's type checker (local hook since no prek repo yet)
-  # Gitleaks - a tool for detecting secrets like passwords, API keys, and tokens
+
+  # Local hooks, if path failure occurs, use the `which` command, like `which gitleaks`, to identify the full path and add it to the `entry:` line
   - repo: local
     hooks:
+      # ty - Astral's type checker (used as a local hook since no prek repo yet)
       - id: ty
         name: ty type checker
         entry: uv run ty check
         language: system
         types: [python]
         pass_filenames: false
+      # Gitleaks - a tool for detecting secrets like passwords, API keys, and tokens
+      # When a secret is detected, gitleaks will create a fingerprint. If the secret is a false positive then this can be excluded in `./gitleaks/.gitleaksignore`.
+      # Alternatively you can add a gitleaks:allow comment to a line to ignore a secret on it. Eg: my_secret = 'some-secret'  #gitleaks:allow
       - id: gitleaks
         name: gitleaks secret scan
         entry: gitleaks git protect --redact=80 --no-banner --timeout 60s -v --max-target-megabytes=2 --pre-commit --staged
+        entry: bash -c 'GL=$(command -v gitleaks || command -v /opt/homebrew/bin/gitleaks || command -v /c/ProgramData/chocolatey/bin/gitleaks 2>/dev/null) || { echo "gitleaks not found by prek, identify path. Skipping now"; exit 0; }; "$GL" git --redact=80 --no-banner --timeout 2 -v --max-target-megabytes=2 --pre-commit --staged'
         language: system
         pass_filenames: false


### PR DESCRIPTION
Many folk find secrets sneak into code bases without notice. To eradicate these problems before they are committed `prek` is amazing.

This MR uses `prek` to catch secrets before they are committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new public "secrets" command entry to streamline secret scanning from the repo.
  * Hardened secret scanner behavior with stricter performance limits and more verbose, cleaner output.
  * Added local pre-commit hooks: an automatic type checker and a pre-commit secret scan to catch issues before commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->