### PR TITLE
fix: install project non-editable in Docker builder stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,21 @@ verify: lint format-check type-check
 
 # Fix - automatically fix what can be fixed
 fix:
-	uvx ruff check --fix .
-	uvx ruff format .
+	uv run ruff check --fix .
+	uv run ruff format .
 
 # Individual targets
 lint:
-	uvx ruff check .
+	uv run ruff check .
 
 format-check:
-	uvx ruff format --check .
+	uv run ruff format --check .
 
 format:
-	uvx ruff format .
+	uv run ruff format .
 
 type-check:
-	uvx ty check
+	uv run ty check
 
 # Install dependencies
 install:

--- a/extensions.py
+++ b/extensions.py
@@ -142,4 +142,6 @@ class CurrentYearExtension(Extension):
         """
         super().__init__(environment)
         environment.filters["current_year"] = current_year
+        # ty's Jinja2 stubs incorrectly narrow globals; newer ty versions
+        # may raise invalid-assignment here
         environment.globals["current_year"] = datetime.now().year

--- a/template/{% if include_docker %}Dockerfile{% endif %}.jinja
+++ b/template/{% if include_docker %}Dockerfile{% endif %}.jinja
@@ -21,7 +21,7 @@ COPY README.md ./
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev
+    uv sync --frozen --no-dev --no-editable
 
 
 # Stage 2: Runtime


### PR DESCRIPTION
When uv sync installs the project in editable mode (the default), it places a .pth file in .venv pointing back to src/. The runtime stage only copied .venv, so src/ was absent and imports failed at runtime.

Adding --no-editable installs the package directly into .venv/lib/pythonX.X/site-packages/, so the runtime stage only needs .venv — no source copy required.

Fixes #31 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened dependency installation in the build to disallow editable installs during image creation.
  * Standardized developer tooling invocation for formatting, linting, fixing, and type-checking.

* **New Features**
  * Exposed the current year as a template global so templates can render it directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->