### PR TITLE
add renovate

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -141,6 +141,11 @@ include_pypi_publish:
   default: true
   when: "{{ include_github_actions }}"
 
+include_renovate:
+  type: bool
+  help: "Include Renovate configuration for automated dependency updates?"
+  default: true
+
 # =============================================================================
 # License
 # =============================================================================

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -48,6 +48,19 @@ git push -u origin main
 
 - **Codecov**: Add your `CODECOV_TOKEN` as a [repository secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository)
 - **PyPI**: Add your `PYPI_TOKEN` as a repository secret. See the [PyPI docs](https://pypi.org/help/#apitoken) for creating a token
+- **Renovate**: Install the [Renovate GitHub App](https://github.com/apps/renovate) and grant it access to your repository. Renovate will open pull requests automatically when new dependency versions are available
+
+### Setting Up Renovate
+
+1. Go to [github.com/apps/renovate](https://github.com/apps/renovate) and click **Install**
+2. Choose your GitHub account or organization
+3. Under **Repository access**, select **Only select repositories** and pick your repository (or choose **All repositories** if you prefer)
+4. Click **Install & Authorize**
+5. Renovate will open an onboarding pull request titled `Configure Renovate` — review it and merge it to activate
+6. From that point on, Renovate will automatically open PRs when new versions of your dependencies are available
+
+!!! tip
+    The `renovate.json` in your project is pre-configured to manage GitHub Actions, `pyproject.toml` dependencies, and the `uv.lock` lockfile. No further configuration is needed.
 
 ### Security Scanning
 
@@ -119,6 +132,7 @@ my-project/
 ├── .pre-commit-config.yaml  # If prek enabled
 ├── Dockerfile               # If Docker enabled
 ├── .dockerignore            # If Docker enabled
+├── renovate.json            # If Renovate enabled
 ├── README.md
 ├── CHANGELOG.md
 ├── LICENSE

--- a/docs/options.md
+++ b/docs/options.md
@@ -40,6 +40,7 @@ When you run `copier copy`, you'll be prompted for the following options.
 | `include_codecov` | bool | `true` | Include Codecov integration (requires GitHub Actions) |
 | `include_security_scanning` | bool | `true` | Include security scanning with Gitleaks, pysentry, and Semgrep (requires GitHub Actions) |
 | `include_pypi_publish` | bool | `true` | Include automatic PyPI publishing (requires GitHub Actions) |
+| `include_renovate` | bool | `true` | Include Renovate configuration for automated dependency updates |
 
 ### License
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "enabledManagers": ["github-actions", "pep621", "uv"]
+}

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -12,6 +12,9 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![ty](https://img.shields.io/badge/type--checked-ty-blue?labelColor=orange)](https://github.com/astral-sh/ty)
 [![License: {{ license }}](https://img.shields.io/badge/License-{{ license | replace('-', '--') }}-yellow.svg)](https://github.com/{{ github_username }}/{{ repository_name }}/blob/main/LICENSE)
+{%- if include_renovate %}
+[![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen.svg?logo=renovate)](https://renovateapp.com/)
+{%- endif %}
 
 {{ project_description }}
 
@@ -110,6 +113,14 @@ prek run --all-files
 ```bash
 make docs-serve
 ```
+{%- endif %}
+
+{%- if include_renovate %}
+## Dependency Updates
+
+This project uses [Renovate](https://renovateapp.com/) to keep dependencies up to date automatically. Renovate will open pull requests when new versions of dependencies are available.
+
+To enable it, install the [Renovate GitHub App](https://github.com/apps/renovate) and grant it access to this repository.
 {%- endif %}
 
 ## License

--- a/template/docs/contributing.md.jinja
+++ b/template/docs/contributing.md.jinja
@@ -89,7 +89,13 @@ To activate it:
 5. Renovate will open an onboarding pull request titled `Configure Renovate` — merge it to activate
 6. Renovate will now open PRs automatically when new dependency versions are available
 
-The `renovate.json` at the root of this project is pre-configured to manage GitHub Actions, `pyproject.toml` dependencies, and the `uv.lock` lockfile.
+The `renovate.json` at the root of this project is pre-configured to manage:
+{%- if include_github_actions %}
+
+- GitHub Actions workflow dependencies
+{%- endif %}
+- Python dependencies (via `pyproject.toml`)
+- `uv.lock` lockfile
 
 {%- endif %}
 ## Code Style

--- a/template/docs/contributing.md.jinja
+++ b/template/docs/contributing.md.jinja
@@ -71,6 +71,27 @@ We use [Conventional Commits](https://www.conventionalcommits.org/). Here are so
 3. Ensure all tests pass
 4. Submit a pull request with a clear description
 
+{%- if include_renovate %}
+## Dependency Updates
+
+This project uses [Renovate](https://renovateapp.com/) for automated dependency updates. Renovate will automatically open pull requests when new versions are available for:
+
+- GitHub Actions
+- Python dependencies (via `pyproject.toml`)
+- `uv.lock` lockfile
+
+To activate it:
+
+1. Go to [github.com/apps/renovate](https://github.com/apps/renovate) and click **Install**
+2. Choose your GitHub account or organization
+3. Under **Repository access**, select this repository (or all repositories)
+4. Click **Install & Authorize**
+5. Renovate will open an onboarding pull request titled `Configure Renovate` — merge it to activate
+6. Renovate will now open PRs automatically when new dependency versions are available
+
+The `renovate.json` at the root of this project is pre-configured to manage GitHub Actions, `pyproject.toml` dependencies, and the `uv.lock` lockfile.
+
+{%- endif %}
 ## Code Style
 
 - We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting

--- a/template/{% if include_renovate %}renovate.json{% endif %}.jinja
+++ b/template/{% if include_renovate %}renovate.json{% endif %}.jinja
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "enabledManagers": ["github-actions", "pep621", "uv"]
+}

--- a/template/{% if include_renovate %}renovate.json{% endif %}.jinja
+++ b/template/{% if include_renovate %}renovate.json{% endif %}.jinja
@@ -3,5 +3,9 @@
   "extends": [
     "config:recommended"
   ],
-  "enabledManagers": ["github-actions", "pep621", "uv"]
+  "enabledManagers": [
+    {%- if include_github_actions %}"github-actions", {% endif -%}
+    "pep621",
+    "uv"
+  ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Renovate integration (enabled by default) to automatically manage dependency updates for GitHub Actions, Python packages, and lockfiles
* **Documentation**
  * Added a setup guide and onboarding steps for enabling Renovate
  * Updated templates and README/contributing content to show Renovate badge and a "Dependency Updates" section when enabled
<!-- end of auto-generated comment: release notes by coderabbit.ai -->